### PR TITLE
Fix syntax highlighting for templates

### DIFF
--- a/syntaxes/Mojolicious.tmLanguage
+++ b/syntaxes/Mojolicious.tmLanguage
@@ -67,7 +67,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(%={,2})</string>
+			<string>^(%(?!%)={,2})</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>

--- a/syntaxes/Mojolicious.tmLanguage
+++ b/syntaxes/Mojolicious.tmLanguage
@@ -13,7 +13,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;%={,2})</string>
+			<string>(&lt;%(?!%)={,2})</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Lines starting with "%%" should not enable syntax highlighting as "%%" is replaced with "%".